### PR TITLE
ユーザ定義の通知テンプレート作成

### DIFF
--- a/app/controllers/custom_notification_controller.rb
+++ b/app/controllers/custom_notification_controller.rb
@@ -11,6 +11,7 @@ class CustomNotificationController < ApplicationController
   def select
     if params[:custom_notification_template_id].present?
       @notification_template = CustomNotificationTemplate.find(params[:custom_notification_template_id])
+      @notification_template.set_issue(@issue)
     else
       @notification_template = CustomNotificationTemplate.new
     end

--- a/app/controllers/custom_notification_controller.rb
+++ b/app/controllers/custom_notification_controller.rb
@@ -2,10 +2,10 @@
 class CustomNotificationController < ApplicationController
   unloadable
   before_filter :find_issue
+  before_filter :find_templates, :only => [:new, :select]
 
   def new
     @notification_template = CustomNotificationTemplate.new
-    @notification_templates = CustomNotificationTemplate.all
   end
 
   def select
@@ -15,7 +15,6 @@ class CustomNotificationController < ApplicationController
     else
       @notification_template = CustomNotificationTemplate.new
     end
-    @notification_templates = CustomNotificationTemplate.all
   end
 
   def send_mail
@@ -27,5 +26,10 @@ class CustomNotificationController < ApplicationController
 
   def find_issue
     @issue = Issue.find(params[:issue_id])
+  end
+
+  def find_templates
+    @notification_templates = CustomNotificationTemplate.where('project_id = ? AND tracker_id = ?',
+                                                               @issue.project.id, @issue.tracker.id).order('name')
   end
 end

--- a/app/controllers/custom_notification_controller.rb
+++ b/app/controllers/custom_notification_controller.rb
@@ -8,6 +8,7 @@ class CustomNotificationController < ApplicationController
     @notification_template = CustomNotificationTemplate.new
   end
 
+  # Refresh template's preview values when user selects it. (called by Ajax)
   def select
     if params[:custom_notification_template_id].present?
       @notification_template = CustomNotificationTemplate.find(params[:custom_notification_template_id])

--- a/app/controllers/custom_notification_controller.rb
+++ b/app/controllers/custom_notification_controller.rb
@@ -3,10 +3,8 @@ class CustomNotificationController < ApplicationController
   unloadable
 
   def new
-    issue = Issue.find(params[:issue_id])
+    # issue = Issue.find(params[:issue_id])
     @notification_template = CustomNotificationTemplate.new
-    @notification_template.subject = issue.subject
-    @notification_template.body = issue.description
   end
 
   # issue.rb に send_notification メソッドがある

--- a/app/controllers/custom_notification_controller.rb
+++ b/app/controllers/custom_notification_controller.rb
@@ -1,16 +1,30 @@
 # coding: utf-8
 class CustomNotificationController < ApplicationController
   unloadable
+  before_filter :find_issue
 
   def new
-    @issue = Issue.find(params[:issue_id])
     @notification_template = CustomNotificationTemplate.new
     @notification_templates = CustomNotificationTemplate.all
   end
 
+  def select
+    if params[:custom_notification_template_id].present?
+      @notification_template = CustomNotificationTemplate.find(params[:custom_notification_template_id])
+    else
+      @notification_template = CustomNotificationTemplate.new
+    end
+    @notification_templates = CustomNotificationTemplate.all
+  end
+
   def send_mail
-    @issue = Issue.find(params[:issue_id])
     @notification_template = CustomNotificationTemplate.find(params[:custom_notification_template][:selected_notification_template])
     CustomNotificationMailer.deliver_issue_by_template(@issue, @notification_template)
+  end
+
+  private
+
+  def find_issue
+    @issue = Issue.find(params[:issue_id])
   end
 end

--- a/app/controllers/custom_notification_controller.rb
+++ b/app/controllers/custom_notification_controller.rb
@@ -3,14 +3,14 @@ class CustomNotificationController < ApplicationController
   unloadable
 
   def new
-    # issue = Issue.find(params[:issue_id])
+    @issue = Issue.find(params[:issue_id])
     @notification_template = CustomNotificationTemplate.new
+    @notification_templates = CustomNotificationTemplate.all
   end
 
-  # issue.rb に send_notification メソッドがある
   def send_mail
     @issue = Issue.find(params[:issue_id])
-    @notification_template = CustomNotificationTemplate.new(params[:custom_notification_template])
+    @notification_template = CustomNotificationTemplate.find(params[:custom_notification_template][:selected_notification_template])
     CustomNotificationMailer.deliver_issue_by_template(@issue, @notification_template)
   end
 end

--- a/app/controllers/custom_notification_templates_controller.rb
+++ b/app/controllers/custom_notification_templates_controller.rb
@@ -3,18 +3,16 @@ class CustomNotificationTemplatesController < ApplicationController
   unloadable
   before_filter :find_project
   before_filter :find_trackers
+  before_filter :build_template, :only => [:new, :create]
 
   def index
     @custom_notification_templates = CustomNotificationTemplate.all
   end
 
   def new
-    @custom_notification_template = CustomNotificationTemplate.new
   end
 
   def create
-    @custom_notification_template = CustomNotificationTemplate.new(params[:custom_notification_template])
-    @custom_notification_template.project = @project
     if @custom_notification_template.save
       flash[:notice] = l(:notice_successful_create)
       redirect_to :action => 'index', :project_id => @project
@@ -33,6 +31,16 @@ class CustomNotificationTemplatesController < ApplicationController
     end
   end
 
+  def update_form
+    if params[:id].present?
+      @custom_notification_template = CustomNotificationTemplate.find(params[:id])
+    else
+      @custom_notification_template = CustomNotificationTemplate.new
+    end
+    @custom_notification_template.project = @project
+    @custom_notification_template.tracker = Tracker.find(params[:tracker_id])
+  end
+
   def destroy
     @custom_notification_template = CustomNotificationTemplate.find(params[:id])
     @custom_notification_template.destroy
@@ -47,5 +55,11 @@ class CustomNotificationTemplatesController < ApplicationController
 
   def find_trackers
     @trackers = @project.trackers.sorted
+  end
+
+  def build_template
+    @custom_notification_template = CustomNotificationTemplate.new(params[:custom_notification_template])
+    @custom_notification_template.project = @project
+    @custom_notification_template.tracker = @project.trackers.first
   end
 end

--- a/app/controllers/custom_notification_templates_controller.rb
+++ b/app/controllers/custom_notification_templates_controller.rb
@@ -1,0 +1,51 @@
+# coding: utf-8
+class CustomNotificationTemplatesController < ApplicationController
+  unloadable
+  before_filter :find_project
+  before_filter :find_trackers
+
+  def index
+    @custom_notification_templates = CustomNotificationTemplate.all
+  end
+
+  def new
+    @custom_notification_template = CustomNotificationTemplate.new
+  end
+
+  def create
+    @custom_notification_template = CustomNotificationTemplate.new(params[:custom_notification_template])
+    @custom_notification_template.project = @project
+    if @custom_notification_template.save
+      flash[:notice] = l(:notice_successful_create)
+      redirect_to :action => 'index', :project_id => @project
+    end
+  end
+
+  def edit
+    @custom_notification_template = CustomNotificationTemplate.find(params[:id])
+  end
+
+  def update
+    @custom_notification_template = CustomNotificationTemplate.find(params[:id])
+    if @custom_notification_template.update_attributes(params[:custom_notification_template])
+      flash[:notice] = l(:notice_successful_update)
+      redirect_to :action => 'index', :project_id => @project
+    end
+  end
+
+  def destroy
+    @custom_notification_template = CustomNotificationTemplate.find(params[:id])
+    @custom_notification_template.destroy
+    redirect_to :action => 'index', :project_id => @project
+  end
+
+  private
+
+  def find_project
+    @project = Project.find(params[:project_id])
+  end
+
+  def find_trackers
+    @trackers = @project.trackers.sorted
+  end
+end

--- a/app/controllers/custom_notification_templates_controller.rb
+++ b/app/controllers/custom_notification_templates_controller.rb
@@ -3,6 +3,7 @@ class CustomNotificationTemplatesController < ApplicationController
   unloadable
   before_filter :find_project
   before_filter :find_trackers
+  before_filter :find_template, :only => [:edit, :update, :destroy]
   before_filter :build_template, :only => [:new, :create]
 
   def index
@@ -20,11 +21,9 @@ class CustomNotificationTemplatesController < ApplicationController
   end
 
   def edit
-    @custom_notification_template = CustomNotificationTemplate.find(params[:id])
   end
 
   def update
-    @custom_notification_template = CustomNotificationTemplate.find(params[:id])
     if @custom_notification_template.update_attributes(params[:custom_notification_template])
       flash[:notice] = l(:notice_successful_update)
       redirect_to :action => 'index', :project_id => @project
@@ -42,7 +41,6 @@ class CustomNotificationTemplatesController < ApplicationController
   end
 
   def destroy
-    @custom_notification_template = CustomNotificationTemplate.find(params[:id])
     @custom_notification_template.destroy
     redirect_to :action => 'index', :project_id => @project
   end
@@ -55,6 +53,10 @@ class CustomNotificationTemplatesController < ApplicationController
 
   def find_trackers
     @trackers = @project.trackers.sorted
+  end
+
+  def find_template
+    @custom_notification_template = CustomNotificationTemplate.find(params[:id])
   end
 
   def build_template

--- a/app/controllers/custom_notification_templates_controller.rb
+++ b/app/controllers/custom_notification_templates_controller.rb
@@ -30,6 +30,7 @@ class CustomNotificationTemplatesController < ApplicationController
     end
   end
 
+  # Update available/selectable field names (called by Ajax).
   def update_form
     if params[:id].present?
       @custom_notification_template = CustomNotificationTemplate.find(params[:id])

--- a/app/models/custom_notification_template.rb
+++ b/app/models/custom_notification_template.rb
@@ -5,5 +5,5 @@ class CustomNotificationTemplate < ActiveRecord::Base
   belongs_to :tracker
   serialize :field_names
 
-  # safe_attributes 'tracker_id', 'name', 'to_users', 'cc_users', 'bcc_users', 'field_names'
+  attr_accessor :selected_notification_template
 end

--- a/app/models/custom_notification_template.rb
+++ b/app/models/custom_notification_template.rb
@@ -1,3 +1,12 @@
+class NotificationField
+  attr_accessor :name, :label
+
+  def initialize(name, label, options = {})
+    self.name = name
+    self.label = label
+  end
+end
+
 class CustomNotificationTemplate < ActiveRecord::Base
   include Redmine::SafeAttributes
   unloadable
@@ -10,5 +19,20 @@ class CustomNotificationTemplate < ActiveRecord::Base
   def set_issue(issue)
     self.subject = issue.subject
     self.body = issue.description
+  end
+
+  def available_fields
+    core_notification_fields = tracker.core_fields.map {|field|
+      NotificationField.new(field, l("field_#{field}".gsub("_id", "").to_sym))
+    }
+    custom_notification_fields = (project.all_issue_custom_fields & tracker.custom_fields).map do |field|
+      NotificationField.new("cf_#{field.id}", field.name)
+    end
+
+    core_notification_fields + custom_notification_fields
+  end
+
+  def selected_fields
+    []
   end
 end

--- a/app/models/custom_notification_template.rb
+++ b/app/models/custom_notification_template.rb
@@ -1,5 +1,9 @@
 class CustomNotificationTemplate < ActiveRecord::Base
+  include Redmine::SafeAttributes
+  unloadable
   belongs_to :project
   belongs_to :tracker
   serialize :field_names
+
+  # safe_attributes 'tracker_id', 'name', 'to_users', 'cc_users', 'bcc_users', 'field_names'
 end

--- a/app/models/custom_notification_template.rb
+++ b/app/models/custom_notification_template.rb
@@ -22,17 +22,20 @@ class CustomNotificationTemplate < ActiveRecord::Base
   end
 
   def available_fields
+    all_available_fields.reject {|f| (self.field_names || []).include?(f.name) }
+  end
+
+  def selected_fields
+    all_available_fields.select {|f| (self.field_names || []).include?(f.name) }
+  end
+
+  def all_available_fields
     core_notification_fields = tracker.core_fields.map {|field|
       NotificationField.new(field, l("field_#{field}".gsub("_id", "").to_sym))
     }
     custom_notification_fields = (project.all_issue_custom_fields & tracker.custom_fields).map do |field|
       NotificationField.new("cf_#{field.id}", field.name)
     end
-
     core_notification_fields + custom_notification_fields
-  end
-
-  def selected_fields
-    []
   end
 end

--- a/app/models/custom_notification_template.rb
+++ b/app/models/custom_notification_template.rb
@@ -1,26 +1,5 @@
-class CustomNotificationTemplate
-  include ActiveModel::Conversion
-  include ActiveModel::Validations
-  extend ActiveModel::Naming
-  extend ActiveModel::Translation
-
-  attr_accessor :subject, :body, :to_users, :cc_users, :bcc_users
-
-  def persisted?; false; end
-
-  def initialize(attributes = {})
-    self.attributes = attributes
-  end
-
-  def attributes=(attributes = {})
-    if attributes
-      attributes.each do |name, value|
-        send "#{name}=", value
-      end
-    end
-  end
-
-  def attributes
-    Hash[instance_variable_names.map{|v| [v[1..-1], instance_variable_get(v)]}]
-  end
+class CustomNotificationTemplate < ActiveRecord::Base
+  belongs_to :project
+  belongs_to :tracker
+  serialize :field_names
 end

--- a/app/models/custom_notification_template.rb
+++ b/app/models/custom_notification_template.rb
@@ -5,5 +5,10 @@ class CustomNotificationTemplate < ActiveRecord::Base
   belongs_to :tracker
   serialize :field_names
 
-  attr_accessor :selected_notification_template
+  attr_accessor :selected_notification_template, :subject, :body
+
+  def set_issue(issue)
+    self.subject = issue.subject
+    self.body = issue.description
+  end
 end

--- a/app/views/custom_notification/_form_notification_modal.html.erb
+++ b/app/views/custom_notification/_form_notification_modal.html.erb
@@ -6,10 +6,12 @@
   <%= error_messages_for 'foo' %>
 
   <div class="box tabular">
-  <p><%= f.text_field :to_users, :size => 60 %></p>
-  <p><%= f.text_field :cc_users, :size => 60 %></p>
-  <p><%= f.text_field :bcc_users, :size => 60 %></p>
-  <p><%#= f.text_area :body, :cols => 60, :rows => 20, :required => true %></p>
+    <p><%= f.select :selected_notification_template, options_from_collection_for_select(@notification_templates, :id, :name),
+      { :include_blank => true }, { :onchange => "" } %>
+    <p><%#= f.text_field :to_users, :size => 60 %></p>
+    <p><%#= f.text_field :cc_users, :size => 60 %></p>
+    <p><%#= f.text_field :bcc_users, :size => 60 %></p>
+    <p><%#= f.text_area :body, :cols => 60, :rows => 20, :required => true %></p>
   </div>
 
   <p class="buttons">

--- a/app/views/custom_notification/_form_notification_modal.html.erb
+++ b/app/views/custom_notification/_form_notification_modal.html.erb
@@ -6,11 +6,10 @@
   <%= error_messages_for 'foo' %>
 
   <div class="box tabular">
-  <p><%= f.text_field :subject, :size => 60, :required => true %></p>
   <p><%= f.text_field :to_users, :size => 60 %></p>
   <p><%= f.text_field :cc_users, :size => 60 %></p>
   <p><%= f.text_field :bcc_users, :size => 60 %></p>
-  <p><%= f.text_area :body, :cols => 60, :rows => 20, :required => true %></p>
+  <p><%#= f.text_area :body, :cols => 60, :rows => 20, :required => true %></p>
   </div>
 
   <p class="buttons">

--- a/app/views/custom_notification/_form_notification_modal.html.erb
+++ b/app/views/custom_notification/_form_notification_modal.html.erb
@@ -1,17 +1,15 @@
 <h3 class="title"><%= l(:label_new_notification) %></h3>
 
-<%= labelled_form_for @notification_template, :url => url_for(:controller => 'custom_notification', :action => 'send_mail'), :remote => true do |f| %>
-
-  <!-- TODO: use partial -->
-  <%= error_messages_for 'foo' %>
+<%= labelled_form_for @notification_template, :url => url_for(:controller => 'custom_notification', :action => 'send_mail'), :remote => true, :html => { :id => 'custom-notification-form' } do |f| %>
 
   <div class="box tabular">
-    <p><%= f.select :selected_notification_template, options_from_collection_for_select(@notification_templates, :id, :name),
-      { :include_blank => true }, { :onchange => "" } %>
-    <p><%#= f.text_field :to_users, :size => 60 %></p>
-    <p><%#= f.text_field :cc_users, :size => 60 %></p>
-    <p><%#= f.text_field :bcc_users, :size => 60 %></p>
-    <p><%#= f.text_area :body, :cols => 60, :rows => 20, :required => true %></p>
+    <% select_url = url_for(:controller => 'custom_notification', :action => 'select') %>
+    <p><%= f.select :selected_notification_template, options_from_collection_for_select(@notification_templates, :id, :name, :selected => @notification_template.id),
+      { :include_blank => true }, { :onchange => "selectCustomNotificationTemplate('#{escape_javascript select_url}', this);" } %>
+    <!-- For preview --> 
+    <p><%= f.text_field :to_users, :size => 60, :disabled => true %></p>
+    <p><%= f.text_field :cc_users, :size => 60, :disabled => true %></p>
+    <p><%= f.text_field :bcc_users, :size => 60, :disabled => true  %></p>
   </div>
 
   <p class="buttons">

--- a/app/views/custom_notification/_form_notification_modal.html.erb
+++ b/app/views/custom_notification/_form_notification_modal.html.erb
@@ -7,13 +7,15 @@
     <p><%= f.select :selected_notification_template, options_from_collection_for_select(@notification_templates, :id, :name, :selected => @notification_template.id),
       { :include_blank => true }, { :onchange => "selectCustomNotificationTemplate('#{escape_javascript select_url}', this);" } %>
     <!-- For preview --> 
+    <p><%= f.text_field :subject, :size => 60, :disabled => true %></p>
     <p><%= f.text_field :to_users, :size => 60, :disabled => true %></p>
     <p><%= f.text_field :cc_users, :size => 60, :disabled => true %></p>
     <p><%= f.text_field :bcc_users, :size => 60, :disabled => true  %></p>
+    <p><%= f.text_area :body, :size => 60, :disabled => true  %></p>
   </div>
 
   <p class="buttons">
-    <%= submit_tag l(:button_create), :name => nil %>
+    <%= submit_tag l(:button_submit), :name => nil %>
     <%= submit_tag l(:button_cancel), :name => nil, :onclick => "hideModal(this);", :type => 'button' %>
   </p>
 <% end %>

--- a/app/views/custom_notification/_notification_hook.html.erb
+++ b/app/views/custom_notification/_notification_hook.html.erb
@@ -1,6 +1,15 @@
+<script type="text/javascript">
+  function selectCustomNotificationTemplate(url, select) {
+    $.ajax({
+      url: url,
+      type: 'get',
+      data: { custom_notification_template_id: $(select).val() }
+    });
+  }
+</script>
+
 <%= link_to(image_tag('email.png', :plugin => 'redmine_custom_notification', :style => 'vertical-align: middle;') + ' ' + l(:field_mail_notification),
             url_for(:controller => 'custom_notification', :action => 'new', :issue_id => @issue),
             :remote => true,
             :method => 'get',
-            :title => 'hoge',
             :tabindex => 200) %>

--- a/app/views/custom_notification/select.js.erb
+++ b/app/views/custom_notification/select.js.erb
@@ -1,0 +1,1 @@
+$('#ajax-modal').html('<%= escape_javascript(render :partial => 'custom_notification/form_notification_modal') %>');

--- a/app/views/custom_notification_templates/_columns.html.erb
+++ b/app/views/custom_notification_templates/_columns.html.erb
@@ -1,0 +1,34 @@
+<table class="query-columns">
+  <tr>
+    <td style="padding-left:0">
+      <%= label_tag "available_columns", l(:description_available_columns) %>
+      <br />
+      <%= select_tag 'available_columns',
+              options_from_collection_for_select(@custom_notification_template.available_fields, :name, :label),
+              :multiple => true, :size => 10, :style => "width:150px; height:200px;",
+              :ondblclick => "moveOptions(this.form.available_columns, this.form.selected_columns);" %>
+    </td>
+    <td class="buttons">
+      <input type="button" value="&#8594;"
+       onclick="moveOptions(this.form.available_columns, this.form.selected_columns);" /><br />
+      <input type="button" value="&#8592;"
+       onclick="moveOptions(this.form.selected_columns, this.form.available_columns);" />
+    </td>
+    <td>
+      <%= label_tag "selected_columns", l(:description_selected_columns) %>
+      <br />
+      <%= select_tag "custom_notification_template[field_names]",
+              options_from_collection_for_select(@custom_notification_template.selected_fields, :name, :label),
+              :id => 'selected_columns', :multiple => true, :size => 10, :style => "width:150px;height:200px;",
+              :ondblclick => "moveOptions(this.form.selected_columns, this.form.available_columns);" %>
+    </td>
+    <td class="buttons">
+      <input type="button" value="&#8593;" onclick="moveOptionUp(this.form.selected_columns);" /><br />
+      <input type="button" value="&#8595;" onclick="moveOptionDown(this.form.selected_columns);" />
+    </td>
+  </tr>
+</table>
+
+<% content_for :header_tags do %>
+<%= javascript_include_tag 'select_list_move' %>
+<% end %>

--- a/app/views/custom_notification_templates/_columns.html.erb
+++ b/app/views/custom_notification_templates/_columns.html.erb
@@ -1,3 +1,4 @@
+<!-- Almost same as app/views/queries/_columns.html.erb, except collections for select tags. -->
 <table class="query-columns">
   <tr>
     <td style="padding-left:0">

--- a/app/views/custom_notification_templates/_form.html.erb
+++ b/app/views/custom_notification_templates/_form.html.erb
@@ -8,7 +8,6 @@
 </div>
 
 <div class="box">
-  <%= @custom_notification_template.field_names %>
   <table>
     <tr>
       <th><label for="custom_notification_template_field_names"><%= l(:field_field_names) %></label></th>

--- a/app/views/custom_notification_templates/_form.html.erb
+++ b/app/views/custom_notification_templates/_form.html.erb
@@ -1,0 +1,8 @@
+<%= error_messages_for @custom_notification_template %>
+<div class="box tabular">
+  <p><%= f.select :tracker_id, options_from_collection_for_select(@trackers, :id, :name, :selected => @custom_notification_template.try(:tracker).try(:id)) %>
+  <p><%= f.text_field :name, :size => 60, :required => true %></p>
+  <p><%= f.text_field :to_users, :size => 60 %></p>
+  <p><%= f.text_field :cc_users, :size => 60 %></p>
+  <p><%= f.text_field :bcc_users, :size => 60 %></p>
+</div>

--- a/app/views/custom_notification_templates/_form.html.erb
+++ b/app/views/custom_notification_templates/_form.html.erb
@@ -1,8 +1,18 @@
 <%= error_messages_for @custom_notification_template %>
 <div class="box tabular">
-  <p><%= f.select :tracker_id, options_from_collection_for_select(@trackers, :id, :name, :selected => @custom_notification_template.try(:tracker).try(:id)) %>
+  <p><%= f.select :tracker_id, options_from_collection_for_select(@trackers, :id, :name, :selected => @custom_notification_template.try(:tracker).try(:id)), {}, { :onchange => "updateForm(this);" } %>
   <p><%= f.text_field :name, :size => 60, :required => true %></p>
   <p><%= f.text_field :to_users, :size => 60 %></p>
   <p><%= f.text_field :cc_users, :size => 60 %></p>
   <p><%= f.text_field :bcc_users, :size => 60 %></p>
+</div>
+
+<div class="box">
+  <%= @custom_notification_template.field_names %>
+  <table>
+    <tr>
+      <th><label for="custom_notification_template_field_names"><%= l(:field_field_names) %></label></th>
+      <td id="notification-fields"><%= render :partial => 'columns' %></td>
+    </tr>
+  </table>
 </div>

--- a/app/views/custom_notification_templates/_form.html.erb
+++ b/app/views/custom_notification_templates/_form.html.erb
@@ -1,3 +1,11 @@
+<!-- FIXME: move to assets/javascripts -->
+<script type="text/javascript">
+  $("#custom-notification-template-form").submit(function() {
+      $("#selected_columns").children('option').attr('selected', true);
+      return true;
+  });
+</script>
+
 <%= error_messages_for @custom_notification_template %>
 <div class="box tabular">
   <p><%= f.select :tracker_id, options_from_collection_for_select(@trackers, :id, :name, :selected => @custom_notification_template.try(:tracker).try(:id)), {}, { :onchange => "updateForm(this);" } %>

--- a/app/views/custom_notification_templates/edit.html.erb
+++ b/app/views/custom_notification_templates/edit.html.erb
@@ -13,7 +13,8 @@
 </script>
 
 <%= labelled_form_for @custom_notification_template,
-  :url => { :controller => 'custom_notification_templates', :action => 'update', :project_id => @project } do |f| %>
+  :url => { :controller => 'custom_notification_templates', :action => 'update', :project_id => @project },
+  :html => { :id => 'custom-notification-template-form' } do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>
   <p>
     <%= f.submit l(:button_change) %>

--- a/app/views/custom_notification_templates/edit.html.erb
+++ b/app/views/custom_notification_templates/edit.html.erb
@@ -1,5 +1,16 @@
-<%= title [l(:label_custom_notification_template_plural), { :controller => 'custom_notification_templates', :action => 'index', :project_id => @project }],
+<%= title [l(:label_custom_notification_template_plural), { :controller => 'custom_notification_templates', :action => 'index', :project_id => @project, :id => nil }],
           @custom_notification_template.name %>
+
+<script type="text/javascript">
+  <% url = url_for(:controller => 'custom_notification_templates', :action => 'update_form', :project_id => @project, :id => @custom_notification_template) %>
+  function updateForm(obj) {
+    $.ajax({
+      url: '<%= escape_javascript url %>',
+      type: 'get',
+      data: { tracker_id: $(obj).val() }
+    });
+  }
+</script>
 
 <%= labelled_form_for @custom_notification_template,
   :url => { :controller => 'custom_notification_templates', :action => 'update', :project_id => @project } do |f| %>

--- a/app/views/custom_notification_templates/edit.html.erb
+++ b/app/views/custom_notification_templates/edit.html.erb
@@ -1,0 +1,10 @@
+<%= title [l(:label_custom_notification_template_plural), { :controller => 'custom_notification_templates', :action => 'index', :project_id => @project }],
+          @custom_notification_template.name %>
+
+<%= labelled_form_for @custom_notification_template,
+  :url => { :controller => 'custom_notification_templates', :action => 'update', :project_id => @project } do |f| %>
+  <%= render :partial => 'form', :locals => { :f => f } %>
+  <p>
+    <%= f.submit l(:button_change) %>
+  </p>
+<% end %>

--- a/app/views/custom_notification_templates/index.html.erb
+++ b/app/views/custom_notification_templates/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="contextual">
   <%= link_to l(:label_new_custom_notification_template),
-      { :controller => 'custom_notification_templates', :action => 'new', :id => @project },
+      { :controller => 'custom_notification_templates', :action => 'new', :project_id => @project },
       :class => 'icon icon-add' %>
 </div>
 
@@ -22,7 +22,7 @@
   </thead>
   <% for template in @custom_notification_templates %>
     <tr class="<%= cycle("odd", "even") %>">
-      <td class="name"><%= link_to h(template.name), { :controller => 'custom_notification_templates', :action => 'edit', :id => @project, :id => template } %></td>
+      <td class="name"><%= link_to h(template.name), { :controller => 'custom_notification_templates', :action => 'edit', :project_id => @project, :id => template } %></td>
       <td><%= template.tracker.name %></td>
       <td class="buttons">
         <%= delete_link :controller => 'custom_notification_templates', :action => 'destroy', :id => template %>

--- a/app/views/custom_notification_templates/index.html.erb
+++ b/app/views/custom_notification_templates/index.html.erb
@@ -1,0 +1,32 @@
+<% if @project.trackers.blank? %>
+  <div class="nodata">
+    <%= simple_format(l(:text_no_tracker_enabled)) %>
+  </div>
+<% end %>
+
+<div class="contextual">
+  <%= link_to l(:label_new_custom_notification_template),
+      { :controller => 'custom_notification_templates', :action => 'new', :id => @project },
+      :class => 'icon icon-add' %>
+</div>
+
+<h2><%= l(:label_custom_notification_template_plural) %></h2>
+
+<table class="list">
+  <thead>
+    <tr>
+      <th><%= l(:label_custom_notification_template) %></th>
+      <th><%= l(:label_tracker) %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <% for template in @custom_notification_templates %>
+    <tr class="<%= cycle("odd", "even") %>">
+      <td class="name"><%= link_to h(template.name), { :controller => 'custom_notification_templates', :action => 'edit', :id => @project, :id => template } %></td>
+      <td><%= template.tracker.name %></td>
+      <td class="buttons">
+        <%= delete_link :controller => 'custom_notification_templates', :action => 'destroy', :id => template %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/custom_notification_templates/new.html.erb
+++ b/app/views/custom_notification_templates/new.html.erb
@@ -13,7 +13,8 @@
 </script>
 
 <%= labelled_form_for @custom_notification_template,
-  :url => { :controller => 'custom_notification_templates', :action => 'create', :project_id => @project } do |f| %>
+  :url => { :controller => 'custom_notification_templates', :action => 'create', :project_id => @project },
+  :html => { :id => 'custom-notification-template-form' } do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>
   <p>
     <%= f.submit l(:button_create) %>

--- a/app/views/custom_notification_templates/new.html.erb
+++ b/app/views/custom_notification_templates/new.html.erb
@@ -1,6 +1,17 @@
 <%= title [l(:label_custom_notification_template_plural), { :controller => 'custom_notification_templates', :action => 'index', :project_id => @project }],
           l(:label_new_custom_notification_template) %>
 
+<script type="text/javascript">
+  <% url = url_for(:controller => 'custom_notification_templates', :action => 'update_form', :project_id => @project) %>
+  function updateForm(obj) {
+    $.ajax({
+      url: '<%= escape_javascript url %>',
+      type: 'get',
+      data: { tracker_id: $(obj).val() }
+    });
+  }
+</script>
+
 <%= labelled_form_for @custom_notification_template,
   :url => { :controller => 'custom_notification_templates', :action => 'create', :project_id => @project } do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>

--- a/app/views/custom_notification_templates/new.html.erb
+++ b/app/views/custom_notification_templates/new.html.erb
@@ -1,0 +1,10 @@
+<%= title [l(:label_custom_notification_template_plural), { :controller => 'custom_notification_templates', :action => 'index', :project_id => @project }],
+          l(:label_new_custom_notification_template) %>
+
+<%= labelled_form_for @custom_notification_template,
+  :url => { :controller => 'custom_notification_templates', :action => 'create', :project_id => @project } do |f| %>
+  <%= render :partial => 'form', :locals => { :f => f } %>
+  <p>
+    <%= f.submit l(:button_create) %>
+  </p>
+<% end %>

--- a/app/views/custom_notification_templates/update_form.js.erb
+++ b/app/views/custom_notification_templates/update_form.js.erb
@@ -1,0 +1,1 @@
+$("#notification-fields").html('<%= escape_javascript(render :partial => 'columns') %>');

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,4 +11,5 @@ ja:
   field_to_users: "To"
   field_cc_users: "Cc"
   field_bcc_users: "Bcc"
+  field_field_names: "本文に表示するフィールド一覧"
   field_body: "本文"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,12 @@
 ja:
+  custom_notification_templates: "チケット通知テンプレート"
+  custom_notification_template: "チケット通知テンプレート"
+
+  label_custom_notification_template_plural: "チケット通知テンプレート"
+  label_custom_notification_template: "チケット通知テンプレート"
+  label_new_custom_notification_template: "新しいチケット通知テンプレート"
   label_new_notification: "チケットのメール通知"
+
   field_to_users: "To"
   field_cc_users: "Cc"
   field_bcc_users: "Bcc"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
   label_new_custom_notification_template: "新しいチケット通知テンプレート"
   label_new_notification: "チケットのメール通知"
 
+  field_selected_notification_template: "通知テンプレート選択"
   field_to_users: "To"
   field_cc_users: "Cc"
   field_bcc_users: "Bcc"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  match 'projects/:project_id/custom_notification_templates/:action', :to => 'custom_notification_templates'
+  match 'projects/:project_id/custom_notification_templates/:id/:action', :to => 'custom_notification_templates'
   match 'custom_notification/new/:issue_id', :to => 'custom_notification#new'
   match 'custom_notification/send_mail/:issue_id', :to => 'custom_notification#send_mail'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   match 'projects/:project_id/custom_notification_templates/:action', :to => 'custom_notification_templates'
   match 'projects/:project_id/custom_notification_templates/:id/:action', :to => 'custom_notification_templates'
   match 'custom_notification/new/:issue_id', :to => 'custom_notification#new'
+  match 'custom_notification/select/:issue_id', :to => 'custom_notification#select'
   match 'custom_notification/send_mail/:issue_id', :to => 'custom_notification#send_mail'
 end

--- a/db/migrate/001_create_custom_notification_templates.rb
+++ b/db/migrate/001_create_custom_notification_templates.rb
@@ -1,0 +1,16 @@
+class CreateCustomNotificationTemplates < ActiveRecord::Migration
+  def self.up
+    create_table :custom_notification_templates do |t|
+      t.column :to_users, :string
+      t.column :cc_users, :string
+      t.column :bcc_users, :string
+      t.column :project_id, :integer, :null => false
+      t.column :tracker_id, :integer, :null => false
+      t.column :field_names, :text
+    end
+  end
+
+  def self.down
+    drop_table :custom_notification_templates
+  end
+end

--- a/db/migrate/002_add_name_to_custom_notification_templates.rb
+++ b/db/migrate/002_add_name_to_custom_notification_templates.rb
@@ -1,0 +1,9 @@
+class AddNameToCustomNotificationTemplates < ActiveRecord::Migration
+  def self.up
+    add_column :custom_notification_templates, :name, :string
+  end
+
+  def self.down
+    remove_column :custom_notification_templates, :name
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,4 @@
+require 'redmine'
 require 'custom_notification/hooks'
 
 Redmine::Plugin.register :redmine_custom_notification do
@@ -8,4 +9,12 @@ Redmine::Plugin.register :redmine_custom_notification do
   url 'https://github.com/ihybs/redmine_custom_notification'
 
   requires_redmine :version_or_higher => '2.4.0'
+
+  permission :custom_notification_templates,
+    { :custom_notification_templates => [:index, :new, :create, :edit, :update, :destroy] },
+    :public => true
+
+  menu :project_menu, :custom_notification_templates,
+    { :controller => 'custom_notification_templates', :action => 'index' },
+    { :caption => :custom_notification_templates, :after => :new_issue, :param => :project_id }
 end

--- a/init.rb
+++ b/init.rb
@@ -15,6 +15,6 @@ Redmine::Plugin.register :redmine_custom_notification do
     :public => true
 
   menu :project_menu, :custom_notification_templates,
-    { :controller => 'custom_notification_templates', :action => 'index' },
+    { :controller => 'custom_notification_templates', :action => 'index', :id => nil },
     { :caption => :custom_notification_templates, :after => :new_issue, :param => :project_id }
 end


### PR DESCRIPTION
## 関連URL

https://github.com/ihybs/redmine_custom_notification/wiki
## 概要
- ユーザがメール通知テンプレートを自分で登録できる。
- メール通知時は、通知テンプレートを選択してメールを送信できる。
## 通知テンプレートの概要(model)
- 宛先(To/Cc/Bcc)
- 紐づくトラッカーのID
- 紐づくプロジェクトのID
  - プロジェクトごとの設定にするか、システム管理者の設定にするかは要検討
- メール本文に出力するフィールドの種類、順序
- メールのヘッダ
- メールのフッタ
