### PR TITLE
定義した通知用テンプレートでメール送信できるようにする

### DIFF
--- a/app/models/custom_notification_mailer.rb
+++ b/app/models/custom_notification_mailer.rb
@@ -2,13 +2,13 @@
 class CustomNotificationMailer < Mailer
   # Builds a mail for notifying using custom notification template
   def issue_by_template(issue, template)
-    @issue_field_values_by_labels = {
-      :description => issue.description
-    }
+    template.set_issue(issue)
+    @issue_field_values_by_labels = template.notification_field_values
 
     mail :to => template.to_users.split(",").map{|addr| addr.strip },
-      :cc => [],
-      :subject => "[Template Mail] #{issue.subject}"
+      :cc => template.cc_users.split(",").map{|addr| addr.strip },
+      :bcc => template.bcc_users.split(",").map{|addr| addr.strip },
+      :subject => template.subject
   end
 
   def self.deliver_issue_by_template(issue, template)


### PR DESCRIPTION
## 概要
- ユーザが定義したメール通知テンプレートを選択し、テンプレート中のTo/Cc/Bcc/フィールド定義にしたがってメール送信ができる。
- 通知テンプレート選択後、送信のタイミングにてプレビューを確認できる（実装的にはAjaxでフォームデータをリロード）
